### PR TITLE
adds sending of ecomm params for remarketing

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -120,7 +120,7 @@ GoogleAdWordsNew.prototype.track = function(track) {
   var mappedConversion = matchConversion(this.options.clickConversions, track.event());
 
   // Remarketing events and parameters
-  // https://support.google.com/google-ads/answer/7305793?hl=en
+  // https://support.google.com/google-ads/answer/3103357
   if (mappedConversion.id) {
     var properties = track.properties({
       orderId: 'transaction_id',

--- a/lib/index.js
+++ b/lib/index.js
@@ -84,7 +84,7 @@ GoogleAdWordsNew.prototype.page = function(page) {
   function sendPageLoadConversion(id, override) {
     var semanticMetadata = reject({
       send_to: (override || configs.accountId) + '/' + id,
-      // the below are not spec'd props of page API, AdWords accepts can accept them for this type of conversions
+      // the below are not spec'd props of page API but AdWords can accept them for this type of conversions
       value: page.options(self.name).value,
       currency: page.options(self.name).currency,
       transaction_id: find(page.options(self.name), 'order_id')
@@ -119,8 +119,16 @@ GoogleAdWordsNew.prototype.track = function(track) {
   var eventName = track.event();
   var mappedConversion = matchConversion(this.options.clickConversions, track.event());
 
+  // Remarketing events and parameters
+  // https://support.google.com/google-ads/answer/7305793?hl=en
   if (mappedConversion.id) {
-    var properties = track.properties({ orderId: 'transaction_id' });
+    var properties = track.properties({
+      orderId: 'transaction_id',
+      ecomm_pagetype: 'page_type',
+      ecomm_prodid: 'product_id',
+      ecomm_pvalue: 'value',
+      ecomm_quantity:'quantity'
+    });
     var metadata = extend(properties, { send_to: (mappedConversion.override || self.options.accountId) + '/' + mappedConversion.id });
     // metadata shouldn't contain PII — warning by Google
     return window.gtag('event', eventName, metadata);


### PR DESCRIPTION
Maps segment event parameters for google ads (adwords) remarketing for Retail.  Maybe all parameters should be added? https://support.google.com/google-ads/answer/7305793?hl=en

