### PR TITLE
[DEST-593] Send multiple reqs with multiple mappings

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -77,9 +77,11 @@ GoogleAdWordsNew.prototype.page = function(page) {
 
   // A mapped event can either be a 'Page Load' or a 'Click' conversion in AdWords.
   // Since the Page Load conversions are meant to just be dropped on a given page, we are mapping named page calls rather than `.track()`
-  var mappedConversion = matchConversion(this.options.pageLoadConversions, pageName);
+  var mappedConversions = matchConversion(this.options.pageLoadConversions, pageName);
 
-  if (mappedConversion.id) return sendPageLoadConversion(mappedConversion.id, mappedConversion.override);
+  each(function(mappedConversion) {
+    sendPageLoadConversion(mappedConversion.id, mappedConversion.override);
+  }, mappedConversions);
 
   function sendPageLoadConversion(id, override) {
     var semanticMetadata = reject({
@@ -117,14 +119,14 @@ GoogleAdWordsNew.prototype.track = function(track) {
   // Depending on what you chose inside Adwords when creating the conversions, we should expect `properties.value` if that is what they want to send
   // But for purchase events, we should map revenue/total
   var eventName = track.event();
-  var mappedConversion = matchConversion(this.options.clickConversions, track.event());
+  var mappedConversions = matchConversion(this.options.clickConversions, track.event());
 
-  if (mappedConversion.id) {
+  each(function(mappedConversion) {
     var properties = track.properties({ orderId: 'transaction_id' });
     var metadata = extend(properties, { send_to: (mappedConversion.override || self.options.accountId) + '/' + mappedConversion.id });
     // metadata shouldn't contain PII — warning by Google
     return window.gtag('event', eventName, metadata);
-  }
+  }, mappedConversions);
 };
 
 /**
@@ -140,9 +142,9 @@ GoogleAdWordsNew.prototype.orderCompleted = function(track) {
   // Depending on what you chose inside Adwords when creating the conversions, we should expect `properties.value` if that is what they want to send
   // But for purchase events, we should map revenue/total
   var eventName = track.event();
-  var mappedConversion = matchConversion(this.options.clickConversions, track.event());
+  var mappedConversions = matchConversion(this.options.clickConversions, track.event());
 
-  if (mappedConversion.id) {
+  each(function(mappedConversion) {
     var properties = track.properties({
       orderId: 'transaction_id',
       order_id: 'transaction_id',
@@ -151,7 +153,7 @@ GoogleAdWordsNew.prototype.orderCompleted = function(track) {
     var metadata = extend(properties, { send_to: (mappedConversion.override || self.options.accountId) + '/' + mappedConversion.id });
     // metadata shouldn't contain PII — warning by Google
     return window.gtag('event', eventName, metadata);
-  }
+  }, mappedConversions);
 };
 
 /**
@@ -162,15 +164,16 @@ GoogleAdWordsNew.prototype.orderCompleted = function(track) {
  */
 
 function matchConversion(mappedConversions, segmentEvent) {
-  var ret = {};
+  var ret = [];
   each(function(setting) {
     var conversion = setting.value || setting;
 
     // to prevent common casing mistakes in our UI
     if (segmentEvent.toLowerCase() === conversion.event.toLowerCase()) {
-      ret.id = conversion.id;
-      // in case customer has multiple AdWords accounts
-      if (conversion.accountId) ret.override = conversion.accountId;
+      ret.push({
+        id: conversion.id,
+        override: conversion.accountId
+      });
     }
   }, mappedConversions);
 


### PR DESCRIPTION
When there are multiple page/track conversion mappings, only one event is sent to Google Ads. This PR fixes the issue.